### PR TITLE
make selected-index two-way binding

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "tests"
   ],
   "devDependencies": {
-    "angular": "~1.2.23",
-    "angular-mocks": "~1.2.23"
+    "angular": ">=1.2.23 <1.7",
+    "angular-mocks": ">=1.2.23 <1.7"
   }
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,7 +22,7 @@
             offset="100"
             wrap-around="true"
             items="items"
-            selected-index="{{selectedIndex}}"
+            selected-index="selectedIndex"
             item-click="itemClickHandler(item)">
     </ng-coverflow>
 </div>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,7 +58,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['Chrome'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.5.1",
-    "karma": "^0.12.23",
-    "karma-jasmine": "^0.1.5",
-    "karma-phantomjs-launcher": "^0.1.4",
+    "karma": "^6.4.1",
+    "karma-chrome-launcher": "^3.1.1",
+    "karma-jasmine": "^5.1.0",
     "protractor": "^1.1.1"
   }
 }

--- a/scripts/ng-coverflow.js
+++ b/scripts/ng-coverflow.js
@@ -47,7 +47,7 @@
                 scope: {
                     items:          '=items',
                     header:         '@',
-                    selectedIndex:  '@',
+                    selectedIndex:  '=?',
                     wrapAround:     '@',
                     itemClick:      '&'
                 },


### PR DESCRIPTION
The original behavior on `selected-index` has no effect, as it is not two-way binding. This PR fixes this.